### PR TITLE
Initial submission for agent image controls.

### DIFF
--- a/spire-flex/Chart.yaml
+++ b/spire-flex/Chart.yaml
@@ -3,23 +3,8 @@ name: spire-flex
 description: A Helm chart for Kubernetes
 icon: https://github.com/spiffe/helm-charts-flex/blob/main/spire-helm.svg
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+# The Helm Chart version
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+# The SPIRE version
+appVersion: "1.8.0"

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -14,6 +14,13 @@ spec:
     spec:
       containers:
         - name: {{ $.Release.Name }}-agent
+          image: {{ join "" (list 
+                   (coalesce ((.Values.agent).image).registry (.Values.image).registry "ghcr.io")
+                   (ternary "" ":" (empty (coalesce ((.Values.agent).image).registryPort (.Values.image).registryPort)))
+                   (coalesce ((.Values.agent).image).registryPort (.Values.image).registryPort)
+                   "/" (coalesce ((.Values.agent).image).name "spiffe/spire-agent") ":"
+                   (coalesce ((.Values.agent).image).tag (.Values.image).tag .Chart.AppVersion)
+                 ) | quote }}
           {{- if ne (((.Values.agent).healthCheck).enable) false }}
           livenessProbe:
             httpGet:

--- a/spire-flex/tests/agentImageAgentImageName.yaml
+++ b/spire-flex/tests/agentImageAgentImageName.yaml
@@ -1,0 +1,28 @@
+suite: test agent with .agent.image.name docker
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image name"
+    template: agent-daemonset.yaml
+    set:
+      agent.image.name: "mycorp/agent"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io/mycorp/agent:1.8.0"
+

--- a/spire-flex/tests/agentImageAgentImageRegistry.yaml
+++ b/spire-flex/tests/agentImageAgentImageRegistry.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .agent.image.registry docker
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image registry"
+    template: agent-daemonset.yaml
+    set:
+      agent.image.registry: "docker"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "docker/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageAgentImageRegistryPort.yaml
+++ b/spire-flex/tests/agentImageAgentImageRegistryPort.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .agent.image.registryPort 3032
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image registry port"
+    template: agent-daemonset.yaml
+    set:
+      agent.image.registryPort: 3032
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io:3032/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageAgentImageTag.yaml
+++ b/spire-flex/tests/agentImageAgentImageTag.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .agent.image.tag latest
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image tag"
+    template: agent-daemonset.yaml
+    set:
+      agent.image.tag: "latest"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io/spiffe/spire-agent:latest"

--- a/spire-flex/tests/agentImageDefault.yaml
+++ b/spire-flex/tests/agentImageDefault.yaml
@@ -1,0 +1,26 @@
+suite: test agent with .image defaults
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Should use the default gcp 1.8.0 image"
+    template: agent-daemonset.yaml
+    set:
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageRegistry.yaml
+++ b/spire-flex/tests/agentImageImageRegistry.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .image.registry docker
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image registry"
+    template: agent-daemonset.yaml
+    set:
+      image.registry: "docker"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "docker/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageRegistryPort.yaml
+++ b/spire-flex/tests/agentImageImageRegistryPort.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .image.registryPort 3032
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image registry port"
+    template: agent-daemonset.yaml
+    set:
+      image.registryPort: 3032
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io:3032/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageTag.yaml
+++ b/spire-flex/tests/agentImageImageTag.yaml
@@ -1,0 +1,27 @@
+suite: test agent with .image.tag latest
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "Demonstrates the use of an override image tag"
+    template: agent-daemonset.yaml
+    set:
+      image.tag: "latest"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: spec
+      - isNotNull:
+          path: spec.template
+      - isNotNull:
+          path: spec.template.spec
+      - isNotNull:
+          path: spec.template.spec.containers
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
+          value: "ghcr.io/spiffe/spire-agent:latest"

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -5,6 +5,39 @@
     "default": {},
     "title": "Helm Flex Schema",
     "properties": {
+        "image": {
+            "type": "object",
+            "default": {},
+            "title": "The .image Schema",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "title": "The .image.registry Schema",
+                    "examples": [
+                        "ghcr.io",
+                        "docker",
+                        "company"
+                    ]
+                },
+                "registryPort": {
+                    "type": "integer",
+                    "title": "The .image.registryPort Schema",
+                    "examples": [
+                        9203,
+                        10001
+                    ]
+                },
+                "tag": {
+                    "type": "string",
+                    "title": "The .image.tag Schema",
+                    "examples": [
+                        "latest",
+                        "1.8.0",
+                        "1.7.2"
+                    ]
+                }
+            }
+        },
         "agent": {
             "type": "object",
             "default": {},
@@ -83,30 +116,83 @@
                         "livePath": "/live",
                         "readyPath": "/ready"
                     }]
+                },
+                "image": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The .agent.healthCheck Schema",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "The .agent.image.name Schema",
+                            "examples": [
+                                "spire/spire-agent",
+                                "company/spire-agent",
+                                "custom/agent"
+                            ]
+                        },
+                        "registry": {
+                            "type": "string",
+                            "title": "The .agent.image.registry Schema",
+                            "examples": [
+                                "ghcr.io",
+                                "docker",
+                                "company"
+                            ]
+                        },
+                        "registryPort": {
+                            "type": "integer",
+                            "title": "The .agent.image.registryPort Schema",
+                            "examples": [
+                                9203,
+                                10001
+                            ]
+                        },
+                        "tag": {
+                            "type": "string",
+                            "title": "The .agent.image.tag Schema",
+                            "examples": [
+                                "latest",
+                                "1.8.0",
+                                "1.7.2"
+                            ]
+                        }
+                    }
                 }
             },
             "examples": [{
-                "healthCheck": { 
+                "healthcheck": {
+                },
+                "image": {
                 }
             }, {
-                "healthCheck": {
+                "healthcheck": {
                     "enable": false
+                },
+                "image": {
+                    "tag": "latest"
                 }
             }, {
-                "healthCheck": {
+                "healthcheck": {
                     "enable": true,
-                    "bindAddress": "localhost",
+                    "bindAddres": "localhost",
                     "bindPort": 80,
                     "livePath": "/live",
                     "readyPath": "/ready"
+                },
+                "image": {
+                    "tag": "1.8.0"
                 }
             }, {
-                "healthCheck": {
+                "healthcheck": {
                     "enable": true,
-                    "bindAddress": "::1",
+                    "bindAddres": "::1",
                     "bindPort": 9000,
                     "livePath": "/live",
                     "readyPath": "/ready"
+                },
+                "image": {
+                    "tag": "1.7.2"
                 }
             }]
         }


### PR DESCRIPTION
Contains updates to the agent daemonset, which now sets:
- spec.template.spec.containers[@name={{.Release.Name}}-agent].image

Adds configuration paths:
- image.repositry
- image.repositryPort
- image.tag
- agent.image.name
- agent.image.repositry
- agent.image.repositryPort
- agent.image.tag

Basic unit testing to ensure overrides / defaults work as desired.

Closes #8