### PR TITLE
Initial submission for agent KeyManager controls.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,6 +8,97 @@
 
 ## Agent Configuration
 
+### Agent Key Manager
+
+The agent is configured by default to use a disk KeyManager with a directory
+setting of "/opt/spire/data/agent/".  This setting prevents node reattestation
+for previously attested nodes, as the agent can present previoulsy accquired,
+current SVIDs to attach to the servers.  
+
+This default corresponds to the agent configuration stanza:
+
+```HCL
+    plugins {
+      KeyManager "disk" {
+        plugin_data {
+          directory = "/opt/spire/data/agent/"
+        }
+      }
+    }
+```
+
+These defaults are not for everyone, to change the Agent KeyManager, configure
+the **agent.keyManager.type** setting and apply the settings for the selected
+KeyManager type.
+
+| Path                  | Type   | Default |
+| --------------------- | ------ | ------- |
+| agent.keyManager.type | string | "disk"  |
+
+> Note: **agent.keyManager.type** can only be set to one of "custom", "disk",
+> or "memory".
+
+#### Agent Key Manager - Custom
+
+> Note: These values only effect the configuration when the **agent.keyManager.type**
+> has the value "custom".
+
+| Path                              | Type             | Default            |
+| --------------------------------- | ---------------- | ------------------ |
+| agent.keyManager.custom.checksum  | string           |                    |
+| agent.keyManager.custom.cmd       | string           |                    |
+| agent.keyManager.custom.data      | array of strings | [ ]                |
+| agent.keyManager.custom.name      | string           | "customKeyManager" |
+
+The **agent.keyManager.custom.checksum** is the sha256sum of the plugin
+executable, as a string value.  It is a required element.  Its purpose is to
+ensure that the plugin has not been altered, a an altered plugin may provide a
+security exploit.
+
+The **agent.keyManager.custom.cmd** is the absolute path of the plugin, as a
+string value. It is a requied element. Its purpose is to ensure that the correct
+plugin is called, as calling an alternative plugin may provide a security
+exploit.
+
+The **agent.keyManager.custom.data** is an array of key and value pairs, presented
+as strings.  If not provided, it will default to an empty array.  Its purpose
+is to pass SPIRE presented configuration information into the plugin.
+
+An example of the setting maight be:
+
+```YAML
+   ...
+   data = [
+     "secure = true",
+     "path = \"/path/required/by/plugin\"",
+     "timeout_seconds = 30"
+   ]
+   ...
+```
+
+These values are dependent on the custom plugin. Currently, we do we do not
+support custom plugins with more sophisticated configuration nestings.
+
+The **agent.keyManager.custom.name** controls the plugin name. It has a default
+of "customKeyManager". Its purpose is to ensure that viewers of the configuration
+file (and logging elements) have the correct plugin name for better team
+coordination.
+
+#### Agent Key Manager - Disk
+
+> Note: These values only effect the configuration when the **agent.keyManager.type**
+> has the value "disk".
+
+| Path                             | Type   | Default                  |
+| -------------------------------- | ------ | ------------------------ |
+| agent.keyManager.disk.directory  | string | "/opt/spire/data/agent/" |
+
+The **agent.keyManager.data.directory** is the path that will hold the disk
+based keyManager.  It is mapped to a volume, and the volume can be controlled
+to be persistent or ephemeral. Its purpose is to provide the directory to hold
+previous identities from node attestation, to prevent a full node re-attestation
+should the SPIRE agent restart.
+
 ### Agent Health Checks
 
 The agent can expose additional endpoint that can be used for health checking.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -7,16 +7,37 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spiffe)](https://artifacthub.io/packages/search?repo=spiffe)
 
 
-## File locations
+## In-Pod locations
 
-Some file in the spire deployment can be relocated.  Relocating files may assist
+Some files in the spire deployment can be relocated.  Relocating files may assist
 in avoiding collisions when installing multiple SPIRE instances on the same
-hardware, or may place files into locations confroming with your file placement
+hardware, or may place files into locations conforming with your file placement
 standards.  Below is a list of relocatable files and their default locations.
 
-| File                          | Config Path      | Default Location           | 
-| ----------------------------- | ---------------- | -------------------------- |
-| Agent Configuration File      | agent.configFile | /opt/spire/conf/agent.conf |
+| File                          | Config Path         | Default Location           | 
+| ----------------------------- | ------------------- | -------------------------- |
+| Agent Configuration File      | agent.configFile    | /opt/spire/conf/agent.conf |
+| Agent Keymanager Directory\*  | agent.keyManagerDir | /opt/spire/data/agent/     |
+
+> Note: Items marked with an asterisk (\*) are optional and will only be used
+  when other configuration setttings activate them.
+
+Changing the location of a file will automatically update the other components
+to expect the file in its specified location.
+
+## In-Node Locations
+
+Some files that map to the nost deployment can be relocated.  Relocating files
+may assist in avoiding collisions when isntalling multiple SPIRE instances on the
+same node, or may place files into locations conforming with your file placement
+standards.  Below is a list of relocatable files and their default locations.
+
+| File                          | Config Path                  | Default Location           | 
+| ----------------------------- | ---------------------------- | -------------------------- |
+| Agent Keymanager Directory\*  | agent.hostPath.keyManagerDir | {agent.keyManagerDir}      |
+
+> Note: Items marked with an asterisk (\*) are optional and will only be used
+  when other configuration setttings activate them.
 
 Changing the location of a file will automatically update the other components
 to expect the file in its specified location.
@@ -249,9 +270,10 @@ coordination.
 > Note: These values only effect the configuration when the **agent.keyManager.type**
 > has the value "disk".
 
-| Path                             | Type   | Default                  |
-| -------------------------------- | ------ | ------------------------ |
-| agent.keyManager.disk.directory  | string | "/opt/spire/data/agent/" |
+| Path                             | Type   | Default                           |
+| -------------------------------- | ------ | --------------------------------- |
+| agent.keyManager.disk.directory  | string | "/opt/spire/data/agent/"          |
+| agent.hostPath.keyManagerDir     | string | {agent.keyManager.disk.directory} |
 
 The **agent.keyManager.data.directory** is the path that will hold the disk
 based keyManager.  It is mapped to a volume, and the volume can be controlled

--- a/spire-flex/templates/agent-configmap.yaml
+++ b/spire-flex/templates/agent-configmap.yaml
@@ -9,6 +9,31 @@ data:
     }
     
     plugins {
+      {{- if eq (default "disk" ((.Values.agent).keyManager).type) "disk" }}
+      KeyManager "disk" {
+        plugin_data {
+          directory = {{ default "/opt/spire/data/agent/" (((.Values.agent).keyManager).disk).directory | quote }}
+        }
+      }
+      {{- end }}
+      {{- if eq ((.Values.agent).keyManager).type "memory" }}
+      KeyManager "memory" {
+      }
+      {{- end }}
+      {{- if eq ((.Values.agent).keyManager).type "custom" }}
+      KeyManager {{ default "customKeyManager" (((.Values.agent).keyManager).custom).name | quote }} {
+        plugin_data {
+          plugin_cmd = {{ required "agent.keyManager.custom.cmd must be set" (((.Values.agent).keyManager).custom).cmd | quote }}
+          plugin_checksum = {{ required "agent.keyManager.custom.checksum must be set" (((.Values.agent).keyManager).custom).checksum | quote }}
+          enabled = {{ ne (((.Values.agent).keyManager).custom).enabled false }}
+          plugin_data {
+            {{- range (((.Values.agent).keyManager).custom).data }}
+            {{ . }}
+            {{- end }}
+          }
+        }
+      }
+      {{- end }}
     }
     {{ if ne (((.Values.agent).healthCheck).enable) false }}
     health_checks {

--- a/spire-flex/templates/agent-configmap.yaml
+++ b/spire-flex/templates/agent-configmap.yaml
@@ -7,7 +7,7 @@ data:
   {{ if (.Values.agent).configFile }}
   {{ base .Values.agent.configFile -}}: |
   {{ else }}
-  agent.config: |
+  agent.conf: |
   {{ end }}
     agent {
     }

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
           image: {{ include "spire-flex.agent.image" . }}
           args:
             - "-config"
-            - {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
+            - {{ default "/opt/spire/conf/agent/agent.conf" (.Values.agent).configFile | quote }} 
           volumeMounts:
             - name: {{ $.Release.Name }}-agent-config
               mountPath: {{ printf "%s/" (dir (default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile)) | quote }}

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -22,7 +22,11 @@ spec:
             - name: {{ $.Release.Name }}-agent-config
               mountPath: {{ printf "%s/" (dir (default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile)) | quote }}
               readOnly: true
-          
+          {{- if eq (default "disk" ((.Values.agent).keyManager).type) "disk" }}
+            - name: {{ $.Release.Name }}-agent-keymanager
+              mountPath: {{ default "/opt/spire/data/agent" (((.Values.agent).keyManager).disk).directory | quote }}
+              readOnly: false
+          {{- end }}
           {{- if ne (((.Values.agent).healthCheck).enable) false }}
           livenessProbe:
             httpGet:
@@ -44,3 +48,9 @@ spec:
         - name: {{ $.Release.Name }}-agent-config
           configMap:
             name: {{ $.Release.Name }}-agent-config
+        {{- if eq (default "disk" ((.Values.agent).keyManager).type) "disk" }}
+        - name: {{ $.Release.Name }}-agent-keymanager
+          hostPath:
+            path: {{ coalesce ((.Values.agent).hostPath).keyManagerDir (default "/opt/spire/data/agent" (((.Values.agent).keyManager).disk).directory) | quote }}
+            type: "Directory"
+        {{- end }}

--- a/spire-flex/tests/agentHealthCheckBindPort.yaml
+++ b/spire-flex/tests/agentHealthCheckBindPort.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckBindPort.yaml
+++ b/spire-flex/tests/agentHealthCheckBindPort.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckDefault.yaml
+++ b/spire-flex/tests/agentHealthCheckDefault.yaml
@@ -15,7 +15,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckDefault.yaml
+++ b/spire-flex/tests/agentHealthCheckDefault.yaml
@@ -21,6 +21,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckDisabled.yaml
+++ b/spire-flex/tests/agentHealthCheckDisabled.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckDisabled.yaml
+++ b/spire-flex/tests/agentHealthCheckDisabled.yaml
@@ -20,6 +20,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
 
   - it: "Expressed settings should correspond to agent daemonset probes"

--- a/spire-flex/tests/agentHealthCheckEnabled.yaml
+++ b/spire-flex/tests/agentHealthCheckEnabled.yaml
@@ -20,6 +20,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
 
             health_checks {

--- a/spire-flex/tests/agentHealthCheckEnabled.yaml
+++ b/spire-flex/tests/agentHealthCheckEnabled.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckLivePath.yaml
+++ b/spire-flex/tests/agentHealthCheckLivePath.yaml
@@ -22,6 +22,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckLivePath.yaml
+++ b/spire-flex/tests/agentHealthCheckLivePath.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckReadyPath.yaml
+++ b/spire-flex/tests/agentHealthCheckReadyPath.yaml
@@ -20,6 +20,11 @@ tests:
             }
             
             plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
             }
             
             health_checks {

--- a/spire-flex/tests/agentHealthCheckReadyPath.yaml
+++ b/spire-flex/tests/agentHealthCheckReadyPath.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: $['data']['agent.config']
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
@@ -22,7 +22,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
@@ -1,0 +1,52 @@
+suite: test .agent.keyManager.type custom all fields
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.name: "bozoKeyManager"
+      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+      agent.keyManager.custom.enabled: true
+      agent.keyManager.custom.data: [
+        "logging = \"on\"",
+        "encryption = true",
+        "rotationMin = 35",
+      ]
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "bozoKeyManager" {
+                plugin_data {
+                  plugin_cmd = "/usr/bin/customKeyManager"
+                  plugin_checksum = "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+                  enabled = true
+                  plugin_data {
+                    logging = "on"
+                    encryption = true
+                    rotationMin = 35
+                  }
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
@@ -1,0 +1,43 @@
+suite: test .agent.keyManager.type custom enabled off
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+      agent.keyManager.custom.enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "customKeyManager" {
+                plugin_data {
+                  plugin_cmd = "/usr/bin/customKeyManager"
+                  plugin_checksum = "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+                  enabled = false
+                  plugin_data {
+                  }
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeCustom_missingChecksum.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_missingChecksum.yaml
@@ -1,0 +1,13 @@
+suite: test .agent.keyManager.type custom missing checksum
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+    asserts:
+      - failedTemplate:
+          errorMessage: "agent.keyManager.custom.checksum must be set"
+

--- a/spire-flex/tests/agentKeyManager_typeCustom_missingCmd.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_missingCmd.yaml
@@ -1,0 +1,13 @@
+suite: test .agent.keyManager.type custom missing cmd
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+    asserts:
+      - failedTemplate:
+          errorMessage: "agent.keyManager.custom.cmd must be set"
+

--- a/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
@@ -1,0 +1,50 @@
+suite: test .agent.keyManager.type custom all fields
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+      agent.keyManager.custom.data: [
+        "logging = \"on\"",
+        "encryption = true",
+        "rotationMin = 35",
+      ]
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "customKeyManager" {
+                plugin_data {
+                  plugin_cmd = "/usr/bin/customKeyManager"
+                  plugin_checksum = "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+                  enabled = true
+                  plugin_data {
+                    logging = "on"
+                    encryption = true
+                    rotationMin = 35
+                  }
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
@@ -20,7 +20,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
@@ -1,0 +1,43 @@
+suite: test .agent.keyManager.type custom enabled off
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: custom
+      agent.keyManager.custom.name: "bonzaiKeyManager"
+      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "bonzaiKeyManager" {
+                plugin_data {
+                  plugin_cmd = "/usr/bin/customKeyManager"
+                  plugin_checksum = "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+                  enabled = true
+                  plugin_data {
+                  }
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeDisk.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk.yaml
@@ -1,0 +1,36 @@
+suite: test .agent.keyManager.type disk
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: disk
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeDisk.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk.yaml
@@ -1,6 +1,7 @@
 suite: test .agent.keyManager.type disk
 templates:
   - agent-configmap.yaml
+  - agent-daemonset.yaml
 tests:
   - it: "Should render the correct agent_config file"
     template: agent-configmap.yaml
@@ -34,3 +35,36 @@ tests:
               ready_path = "/ready"
             }
 
+  - it: "The agent daemonset has a volume for the keymanager when the type is set to disk"
+    template: agent-daemonset.yaml
+    set:
+      agent.keyManager.type: disk
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-keymanager")].hostPath.path
+          value: "/opt/spire/data/agent"
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-keymanager")].hostPath.type
+          value: "Directory"
+
+  - it: "The agent daemonset has a volumemount for the keymanager volume when the type is set to disk"
+    template: agent-daemonset.yaml
+    set:
+      agent.keyManager.type: disk
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-keymanager")].mountPath
+          value: "/opt/spire/data/agent"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-keymanager")].readOnly
+          value: false

--- a/spire-flex/tests/agentKeyManager_typeDisk.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk.yaml
@@ -13,7 +13,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
@@ -1,0 +1,37 @@
+suite: test .agent.keyManager.type disk with directory
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: disk
+      agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/var/lib/spire-agent/"
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
@@ -1,4 +1,4 @@
-suite: test .agent.keyManager.type disk with directory
+suite: test .agent.keyManager.type disk with directory and hostPath
 templates:
   - agent-configmap.yaml
   - agent-daemonset.yaml
@@ -8,6 +8,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      agent.hostpath.keyManagerDir: "/opt/lib/spire-agent/"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -42,6 +43,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      agent.hostPath.keyManagerDir: "/opt/lib/spire-agent/"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -50,7 +52,7 @@ tests:
           namespace: "NAMESPACE"
       - equal:
           path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-keymanager")].hostPath.path
-          value: "/var/lib/spire-agent/"
+          value: "/opt/lib/spire-agent/"
       - equal:
           path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-keymanager")].hostPath.type
           value: "Directory"
@@ -60,6 +62,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      agent.hostPath.keyManagerDir: "/opt/lib/spire-agent/"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"

--- a/spire-flex/tests/agentKeyManager_typeMemory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeMemory.yaml
@@ -1,0 +1,33 @@
+suite: test .agent.keyManager.type memory
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should render the correct agent_config file"
+    template: agent-configmap.yaml
+    set:
+      agent.keyManager.type: "memory"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: data.agent_config
+          value: |
+            agent {
+            }
+
+            plugins {
+              KeyManager "memory" {
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+

--- a/spire-flex/tests/agentKeyManager_typeMemory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeMemory.yaml
@@ -13,7 +13,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $["data"]["agent.conf"]
           value: |
             agent {
             }

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -113,6 +113,21 @@
                         }
                     }
                 },
+                "hostPath": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The .agent.hostPath Schema",
+                    "properties": {
+                        "keyManagerDir": {
+                            "type": "string",
+                            "title": "The .agent.hostPath.keyManager Schema",
+                            "examples": [
+                                "/opt/spire/data/agent/",
+                                "/var/lib/spire/agent/"
+                            ]
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "default": {},

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -69,22 +69,100 @@
                                 "/i_am_ready"
                             ]
                         }
-                    },
-                    "examples": [{
-                        "enable": false
-                    }, {
-                        "enable": true,
-                        "bindAddress": "localhost",
-                        "bindPort": 80,
-                        "livePath": "/live",
-                        "readyPath": "/ready"
-                    }, {
-                        "enable": true,
-                        "bindAddress": "::1",
-                        "bindPort": 9000,
-                        "livePath": "/live",
-                        "readyPath": "/ready"
-                    }]
+                    }
+                },
+                "keyManager": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The .agent.keyManager Schema",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [ "custom", "disk", "memory" ],
+                            "default": "disk",
+                            "title": "The .agent.keyManager.type Schema",
+                            "examples": [
+                                "custom",
+                                "disk",
+                                "memory"
+                            ]
+                        },
+                        "disk": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The .agent.keyManager.disk Schema",
+                            "properties": {
+                                "directory": {
+                                    "type": "string",
+                                    "default": "/opt/spire/data/agent/",
+                                    "title": "The .agent.keyManager.type.disk Schema",
+                                    "examples": [
+                                        "/opt/spire/data/agent/",
+                                        "/var/lib/spire-agent/"
+                                    ]
+                                }
+                            }
+                        },
+                        "custom": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The .agent.keyManager.custom Schema",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "default": "customKeyManager",
+                                    "title": "The .agent.keyManager.custom.name Schema",
+                                    "examples": [
+                                        "customKeyManager",
+                                        "coprateKeyManager"
+                                    ]
+                                },
+                                "checksum": {
+                                    "type": "string",
+                                    "title": "The .agent.keyManager.custom.checksum Schema",
+                                    "examples": [
+                                        "1725b8b7071f09f1a15255f0e580bc6c811190902d144f63c0a3dd0f24979c6e"
+                                    ]
+                                },
+                                "cmd": {
+                                    "type": "string",
+                                    "title": "The .agent.keyManager.custom.cmd Schema",
+                                    "examples": [
+                                        "/opt/spire/agent/plugins/customKeyManager"
+                                    ]
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "title": "The .agent.keyManager.custom.data Schema",
+                                    "examples": [
+                                        "/opt/spire/agent/plugins/customKeyManager"
+                                    ]
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "title": "The .agent.keyManager.custom.enabled Schema",
+                                    "examples": [
+                                        true,
+                                        false
+                                    ]
+                                },
+                                "data": {
+                                    "type": "array",
+                                    "default": [ ],
+                                    "title": "The .agent.keyManager.custom.data Schema",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "examples": [
+                                        "logging = true",
+                                        "delay = 32",
+                                        "name = \"item\""
+                                    ]
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "examples": [{


### PR DESCRIPTION
Defaults to KeyManager "disk" with directory at "/opt/spire/data/agent/"

Adds keys:
- agent.keyManager.type (enum [custom, disk, memory], default disk)

- agent.keyManager.disk.directory (string, default "/opt/spire/data/agent/" when agent.keyManager.type="disk")

- agent.keyManager.custom.name (string, default "customKeyManager" when agent.keyManager.type="custom")

- agent.keyManager.custom.cmd (required) (string, required when agent.keyManager.type="custom")

- agent.keyManager.custom.checksum (required) (string, required when agent.keyManager.type="custom")

- agent.keyManager.custom.enabled (boolean, default true when  agent.keyManager.type="custom")

- agent.keyManager.custom.data (string, required when agent.keyManager.type="custom")

Unit tests for above.

Documentation for above.