### PR TITLE
Add Agent config file mounting and agent cli arg parameter.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,36 @@
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spiffe)](https://artifacthub.io/packages/search?repo=spiffe)
 
+## File locations
+
+Some file in the spire deployment can be relocated.  Relocating files may assist
+in avoiding collisions when installing multiple SPIRE instances on the same
+hardware, or may place files into locations confroming with your file placement
+standards.  Below is a list of relocatable files and their default locations.
+
+| File                          | Config Path      | Default Location           | 
+| ----------------------------- | ---------------- | -------------------------- |
+| Agent Configuration File      | agent.configFile | /opt/spire/conf/agent.conf |
+
+Changing the location of a file will automatically update the other components
+to expect the file in its specified location.
+
 ## Agent Configuration
+
+Agent configuration covers the agent installation and the configured behavior
+of the installed agent.  
+
+### Agent Config File
+
+The agent config file contains the configuration elements passed to the agent
+at agent launch.
+
+| Path             | Type   | Default                      | 
+| ---------------- | ------ | ---------------------------- |
+| agent.configFile | string | "/opt/spire/conf/agent.conf" |
+
+**agent.configFile** controls both the in-container path of the config file as
+well as the command line agent parameters that reference the config file.
 
 ### Agent Health Checks
 

--- a/spire-flex/templates/agent-configmap.yaml
+++ b/spire-flex/templates/agent-configmap.yaml
@@ -4,7 +4,11 @@ metadata:
   name: {{ $.Release.Name }}-agent-config
   namespace: {{ $.Release.Namespace }}
 data:
-  agent_config: |
+  {{ if (.Values.agent).configFile }}
+  {{ base .Values.agent.configFile -}}: |
+  {{ else }}
+  agent.config: |
+  {{ end }}
     agent {
     }
     

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
             - "-config"
             - {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
           volumeMounts:
-            - name: {{ $.Release.Name }}-agent-config-volume
+            - name: {{ $.Release.Name }}-agent-config
               mountPath: {{ printf "%s/" (dir (default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile)) | quote }}
               readOnly: true
           
@@ -41,6 +41,6 @@ spec:
               path: {{ default "/ready" (((.Values.agent).healthCheck).readyPath) | quote }}
           {{- end }}
       volumes:
-        - name: {{ $.Release.Name }}-agent-config-volume
+        - name: {{ $.Release.Name }}-agent-config
           configMap:
             name: {{ $.Release.Name }}-agent-config

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
             - {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
           volumeMounts:
             - name: {{ $.Release.Name }}-agent-config-volume
-              mountPath: {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
+              mountPath: {{ printf "%s/" (dir (default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile)) | quote }}
               readOnly: true
           
           {{- if ne (((.Values.agent).healthCheck).enable) false }}

--- a/spire-flex/templates/agent-daemonset.yaml
+++ b/spire-flex/templates/agent-daemonset.yaml
@@ -14,6 +14,13 @@ spec:
     spec:
       containers:
         - name: {{ $.Release.Name }}-agent
+          args:
+            - "-config"
+            - {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
+          volumeMounts:
+            - name: {{ $.Release.Name }}-agent-config-volume
+              mountPath: {{ default "/opt/spire/conf/agent/agent.conf" ($.Values.agent).configFile }}
+              readOnly: true
           {{- if ne (((.Values.agent).healthCheck).enable) false }}
           livenessProbe:
             httpGet:
@@ -30,4 +37,8 @@ spec:
               host: {{ default "localhost" (((.Values.agent).healthCheck).bindAddress) | quote }}
               port: {{ default 80 (((.Values.agent).healthCheck).bindPort) }}
               path: {{ default "/ready" (((.Values.agent).healthCheck).readyPath) | quote }}
-         {{- end }}
+          {{- end }}
+      volumes:
+        - name: {{ $.Release.Name }}-agent-config-volume
+          configMap:
+            name: {{ $.Release.Name }}-agent-config

--- a/spire-flex/tests/agentConfigFilePath.yaml
+++ b/spire-flex/tests/agentConfigFilePath.yaml
@@ -23,7 +23,7 @@ tests:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
-          value: "/etc/spire/agent_goofy"
+          value: "/etc/spire/"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
           value: true

--- a/spire-flex/tests/agentConfigFilePath.yaml
+++ b/spire-flex/tests/agentConfigFilePath.yaml
@@ -1,0 +1,44 @@
+suite: test .agent.config.filePath /etc/spire/agent.conf
+templates:
+  - agent-daemonset.yaml
+  - agent-configmap.yaml
+tests:
+  - it: "agent.configFile setting changes agent config file location"
+    template: agent-daemonset.yaml
+    set:
+      agent.configFile: "/etc/spire/agent_goofy"
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[0]
+          value: "-config"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[1]
+          value: "/etc/spire/agent_goofy"
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
+          value: "/etc/spire/agent_goofy"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
+          value: true
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config-volume")].configMap.name
+          value: "RELEASE-NAME-agent-config"
+  - it: "agent.configFile setting changes agent config map key"
+    template: agent-configmap.yaml
+    set:
+      agent.configFile: "/etc/spire/agent_goofy"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - isNotNull:
+          path: data.agent_goofy

--- a/spire-flex/tests/agentConfigFilePath.yaml
+++ b/spire-flex/tests/agentConfigFilePath.yaml
@@ -20,15 +20,15 @@ tests:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[1]
           value: "/etc/spire/agent_goofy"
       - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")]
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")].mountPath
           value: "/etc/spire/"
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")].readOnly
           value: true
       - equal:
-          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config-volume")].configMap.name
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config")].configMap.name
           value: "RELEASE-NAME-agent-config"
   - it: "agent.configFile setting changes agent config map key"
     template: agent-configmap.yaml

--- a/spire-flex/tests/agentConfigFilePath_default.yaml
+++ b/spire-flex/tests/agentConfigFilePath_default.yaml
@@ -17,13 +17,13 @@ tests:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[1]
           value: "/opt/spire/conf/agent/agent.conf"
       - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")]
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")].mountPath
           value: "/opt/spire/conf/agent/"
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config")].readOnly
           value: true
       - equal:
-          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config-volume")].configMap.name
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config")].configMap.name
           value: "RELEASE-NAME-agent-config"

--- a/spire-flex/tests/agentConfigFilePath_default.yaml
+++ b/spire-flex/tests/agentConfigFilePath_default.yaml
@@ -20,7 +20,7 @@ tests:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
-          value: "/opt/spire/conf/agent/agent.conf"
+          value: "/opt/spire/conf/agent/"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
           value: true

--- a/spire-flex/tests/agentConfigFilePath_default.yaml
+++ b/spire-flex/tests/agentConfigFilePath_default.yaml
@@ -1,0 +1,29 @@
+suite: test .agent.config.filePath (defalt)
+templates:
+  - agent-daemonset.yaml
+tests:
+  - it: "agent.configFile setting defaults to something like a standard unzip install"
+    template: agent-daemonset.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: "apps/v1"
+          kind: "DaemonSet"
+          name: "RELEASE-NAME-agent-daemonset"
+          namespace: "NAMESPACE"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[0]
+          value: "-config"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].args[1]
+          value: "/opt/spire/conf/agent/agent.conf"
+      - isNotNull:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")]
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].mountPath
+          value: "/opt/spire/conf/agent/agent.conf"
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].volumeMounts[?(@.name == "RELEASE-NAME-agent-config-volume")].readOnly
+          value: true
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "RELEASE-NAME-agent-config-volume")].configMap.name
+          value: "RELEASE-NAME-agent-config"

--- a/spire-flex/tests/agentHealthCheckBindPort.yaml
+++ b/spire-flex/tests/agentHealthCheckBindPort.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckDefault.yaml
+++ b/spire-flex/tests/agentHealthCheckDefault.yaml
@@ -15,7 +15,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckDisabled.yaml
+++ b/spire-flex/tests/agentHealthCheckDisabled.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckEnabled.yaml
+++ b/spire-flex/tests/agentHealthCheckEnabled.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckLivePath.yaml
+++ b/spire-flex/tests/agentHealthCheckLivePath.yaml
@@ -16,7 +16,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/tests/agentHealthCheckReadyPath.yaml
+++ b/spire-flex/tests/agentHealthCheckReadyPath.yaml
@@ -14,7 +14,7 @@ tests:
           name: "RELEASE-NAME-agent-config"
           namespace: "NAMESPACE"
       - equal:
-          path: data.agent_config
+          path: $['data']['agent.config']
           value: |
             agent {
             }

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -10,6 +10,15 @@
             "default": {},
             "title": "The .agent Schema",
             "properties": {
+                "configFile": {
+                    "type": "string",
+                    "default": "/opt/spire/conf/agent/agent.conf",
+                    "title": "The .agent.configFile Schema",
+                    "examples": [
+                        "/run/spire/config/agent.conf",
+                        "/etc/spire/agent.conf"
+                    ]
+                },
                 "healthCheck": {
                     "type": "object",
                     "default": {},
@@ -69,83 +78,9 @@
                                 "/i_am_ready"
                             ]
                         }
-                    },
-                    "examples": [{
-                        "enable": false
-                    }, {
-                        "enable": true,
-                        "bindAddress": "localhost",
-                        "bindPort": 80,
-                        "livePath": "/live",
-                        "readyPath": "/ready"
-                    }, {
-                        "enable": true,
-                        "bindAddress": "::1",
-                        "bindPort": 9000,
-                        "livePath": "/live",
-                        "readyPath": "/ready"
-                    }]
+                    }
                 }
-            },
-            "examples": [{
-                "healthCheck": { 
-                }
-            }, {
-                "healthCheck": {
-                    "enable": false
-                }
-            }, {
-                "healthCheck": {
-                    "enable": true,
-                    "bindAddress": "localhost",
-                    "bindPort": 80,
-                    "livePath": "/live",
-                    "readyPath": "/ready"
-                }
-            }, {
-                "healthCheck": {
-                    "enable": true,
-                    "bindAddress": "::1",
-                    "bindPort": 9000,
-                    "livePath": "/live",
-                    "readyPath": "/ready"
-                }
-            }]
-        }
-    },
-    "examples": [{
-        "agent": {
-        }
-    }, {
-        "agent": {
-            "healthCheck": {
             }
         }
-    }, {
-        "agent": {
-            "healthCheck": {
-                "enable": false
-            }
-        }
-    }, {
-        "agent": {
-            "healthCheck": {
-                "enable": true,
-                "bindAddress": "localhost",
-                "bindPort": 80,
-                "livePath": "/live",
-                "readyPath": "/ready"
-            }
-        }
-    }, {
-        "agent": {
-            "healthCheck": {
-                "enable": true,
-                "bindAddress": "::1",
-                "bindPort": 9000,
-                "livePath": "/live",
-                "readyPath": "/ready"
-            }
-        }
-    }]
+    }
 }


### PR DESCRIPTION
Closes #10

agent-configmap now has the data property for the configuration informaiton set dynamically by the file at the end of agent.configFile.

Test updates to set the basic default of the config file name to agent.conf which requires a different style of json path specification to accomodate the internal period in the path name.