### PR TITLE
Add serviceName and servicePort configurations to the agent.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,6 +6,14 @@
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spiffe)](https://artifacthub.io/packages/search?repo=spiffe)
 
+## Component Names
+
+Some componets support renaming.  When renaming components, we highly recommend
+that you select names that would not conflict with additional chart installations.
+
+| Component                     | Config Path         | Default Value           | 
+| ----------------------------- | ------------------- | ----------------------- |
+| Server Service                | server.serviceName  | { Release.Name }-server |
 
 ## In-Pod locations
 
@@ -280,3 +288,23 @@ based keyManager.  It is mapped to a volume, and the volume can be controlled
 to be persistent or ephemeral. Its purpose is to provide the directory to hold
 previous identities from node attestation, to prevent a full node re-attestation
 should the SPIRE agent restart.
+
+## Server Configuration
+
+The server is accessed through a Kubernetes Service, which distributes server
+connections to one more more backend server instances.  The backend instances
+then handle the requests, replying directly to the agents via client sockets.
+
+### Server Service Settings
+
+The server service provides a single DNS name referenced point of access for
+all spire server instances within a deployment.  Connections made to this
+Kubernetes service are relayed to one of the backing server instances.
+
+The values associated with the service settigns include:
+
+| Path                     | Type   | Defaults                |
+| ------------------------ | ------ | ----------------------- |
+| server.serviceName       | string | { Release.Name }-server |
+| server.servicePort       | int    | 8081                    |
+

--- a/spire-flex/templates/agent-configmap.yaml
+++ b/spire-flex/templates/agent-configmap.yaml
@@ -10,6 +10,8 @@ data:
   agent.conf: |
   {{ end }}
     agent {
+      server_address = {{ default (printf "%s-server" .Release.Name) (.Values.server).serviceName | quote }}
+      server_port = {{ default 8081 (.Values.server).servicePort }}
     }
     
     plugins {

--- a/spire-flex/templates/server-service.yaml
+++ b/spire-flex/templates/server-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ default (printf "%s-server" .Release.Name) (.Values.server).serviceName | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $.Release.Name }}-server
+  ports:
+    - port: {{ default 8081 (.Values.server).servicePort }}
+      protocol: "TCP"

--- a/spire-flex/tests/agentHealthCheckBindPort.yaml
+++ b/spire-flex/tests/agentHealthCheckBindPort.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckDefault.yaml
+++ b/spire-flex/tests/agentHealthCheckDefault.yaml
@@ -18,6 +18,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckDisabled.yaml
+++ b/spire-flex/tests/agentHealthCheckDisabled.yaml
@@ -17,6 +17,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckEnabled.yaml
+++ b/spire-flex/tests/agentHealthCheckEnabled.yaml
@@ -17,6 +17,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckLivePath.yaml
+++ b/spire-flex/tests/agentHealthCheckLivePath.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentHealthCheckReadyPath.yaml
+++ b/spire-flex/tests/agentHealthCheckReadyPath.yaml
@@ -17,6 +17,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
             
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
@@ -25,6 +25,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
@@ -23,6 +23,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeDisk.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk.yaml
@@ -17,6 +17,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
@@ -18,6 +18,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
@@ -19,6 +19,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeMemory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeMemory.yaml
@@ -16,6 +16,8 @@ tests:
           path: $["data"]["agent.conf"]
           value: |
             agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 8081
             }
 
             plugins {

--- a/spire-flex/tests/server_serviceName.yaml
+++ b/spire-flex/tests/server_serviceName.yaml
@@ -1,0 +1,59 @@
+suite: test server.serviceName myserver
+set:
+  Release.Name: devcluster
+templates:
+  - agent-configmap.yaml
+  - server-service.yaml
+tests:
+  - it: "Should render with server_address = \"myserver\""
+    template: agent-configmap.yaml
+    set:
+      server.serviceName: "myserver"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: $["data"]["agent.conf"]
+          value: |
+            agent {
+              server_address = "myserver"
+              server_port = 8081
+            }
+            
+            plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+
+  - it: "Should render with name = \"myserver\""
+    template: server-service.yaml
+    set:
+      server.serviceName: "myserver"
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "Service"
+          name: "myserver"
+          namespace: "NAMESPACE"
+      - equal:
+          path: "metadata.name"
+          value: "myserver"
+      - isNotNull:
+          path: "spec.ports[?(@.port == 8081)]"
+      - equal:
+          path: "spec.ports[?(@.port == 8081)].protocol"
+          value: "TCP"

--- a/spire-flex/tests/server_serviceName_default.yaml
+++ b/spire-flex/tests/server_serviceName_default.yaml
@@ -1,14 +1,12 @@
-suite: test .agent.keyManager.type custom enabled off
+suite: test server.serviceName (default)
+set:
+  Release.Name: devcluster
 templates:
   - agent-configmap.yaml
+  - server-service.yaml
 tests:
-  - it: "Should render the correct agent_config file"
+  - it: "Should render with server_address = \"RELEASE-NAME-server\""
     template: agent-configmap.yaml
-    set:
-      agent.keyManager.type: custom
-      agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
-      agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
-      agent.keyManager.custom.enabled: false
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -22,15 +20,11 @@ tests:
               server_address = "RELEASE-NAME-server"
               server_port = 8081
             }
-
+            
             plugins {
-              KeyManager "customKeyManager" {
+              KeyManager "disk" {
                 plugin_data {
-                  plugin_cmd = "/usr/bin/customKeyManager"
-                  plugin_checksum = "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
-                  enabled = false
-                  plugin_data {
-                  }
+                  directory = "/opt/spire/data/agent/"
                 }
               }
             }
@@ -43,3 +37,19 @@ tests:
               ready_path = "/ready"
             }
 
+  - it: "Should render with name = \"RELEASE-NAME-server\""
+    template: server-service.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "Service"
+          name: "RELEASE-NAME-server"
+          namespace: "NAMESPACE"
+      - equal:
+          path: "metadata.name"
+          value: "RELEASE-NAME-server"
+      - isNotNull:
+          path: "spec.ports[?(@.port == 8081)]"
+      - equal:
+          path: "spec.ports[?(@.port == 8081)].protocol"
+          value: "TCP"

--- a/spire-flex/tests/server_servicePort.yaml
+++ b/spire-flex/tests/server_servicePort.yaml
@@ -1,0 +1,59 @@
+suite: test server.servicePort 5000
+set:
+  Release.Name: devcluster
+templates:
+  - agent-configmap.yaml
+  - server-service.yaml
+tests:
+  - it: "Should render with server_address = \"myserver\""
+    template: agent-configmap.yaml
+    set:
+      server.servicePort: 5000
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "ConfigMap"
+          name: "RELEASE-NAME-agent-config"
+          namespace: "NAMESPACE"
+      - equal:
+          path: $["data"]["agent.conf"]
+          value: |
+            agent {
+              server_address = "RELEASE-NAME-server"
+              server_port = 5000
+            }
+            
+            plugins {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
+              }
+            }
+            
+            health_checks {
+              listener_enabled = true
+              bind_address = "localhost"
+              bind_port = 80
+              live_path = "/live"
+              ready_path = "/ready"
+            }
+
+  - it: "Should render with name = \"myserver\""
+    template: server-service.yaml
+    set:
+      server.servicePort: 5000
+    asserts:
+      - containsDocument:
+          apiVersion: "v1"
+          kind: "Service"
+          name: "RELEASE-NAME-server"
+          namespace: "NAMESPACE"
+      - equal:
+          path: "metadata.name"
+          value: "RELEASE-NAME-server"
+      - isNotNull:
+          path: "spec.ports[?(@.port == 5000)]"
+      - equal:
+          path: "spec.ports[?(@.port == 5000)].protocol"
+          value: "TCP"

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -265,6 +265,31 @@
                     }
                 }
             }
+        },
+        "server": {
+            "type": "object",
+            "default": {},
+            "title": "The .server Schema",
+            "properties": {
+                "serviceName": {
+                    "type": "string",
+                    "default": "RELEASE-NAME-server",
+                    "title": "The .server.serviceName Schema",
+                    "examples": [
+                        "/run/spire/config/agent.conf",
+                        "/etc/spire/agent.conf"
+                    ]
+                },
+                "servicePort": {
+                    "type": "integer",
+                    "default": 8081,
+                    "title": "The .server.servicePort Schema",
+                    "examples": [
+                        8081,
+                        8443
+                    ]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Impacts the agent configmap and adds the server serivce.

- Addition of a ClusterIP service (but no server instances yet).
- Testing to ensure the two items integrate properly.
- Updates to values.schema.yaml to define settings.
- Updates to the CONFIGURATION.md documentation.