### PR TITLE
Add trust domain to the agent configmap.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,9 +6,29 @@
 [![Development Phase](https://github.com/spiffe/spiffe/blob/main/.img/maturity/dev.svg)](https://github.com/spiffe/spiffe/blob/main/MATURITY.md#development)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spiffe)](https://artifacthub.io/packages/search?repo=spiffe)
 
+## Required Settings
+
+Some settings are required, but have no defaults.  The settings should be chosen
+to match your deployment environment.  We encourage you to take a short moment
+to select values that make sense for your enviornment, for example, if creating
+a prototype, set the **trustdomain** to 'prototype.department.company.com'.
+
+| Component          | Config Path | Example Values          | 
+| ------------------ | ----------- | ----------------------- |
+| SPIRE Trust Domain | trustdomain | propulsion.yoyodyne.com |
+
+## Global Settings
+
+Some settings apply to the entire installation.  To clarify they are not a
+subcomponent of the agent or server, they are top-level settings.
+
+| Component          | Config Path | Example Values          | 
+| ------------------ | ----------- | ----------------------- |
+| SPIRE Trust Domain | trustdomain | propulsion.yoyodyne.com |
+
 ## Component Names
 
-Some componets support renaming.  When renaming components, we highly recommend
+Some components support renaming.  When renaming components, we highly recommend
 that you select names that would not conflict with additional chart installations.
 
 | Component                     | Config Path         | Default Value           | 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ coordinating the other clusters.
 To install a cluster named "spire-demo" with a trust domain of "demo.trust.domain"
 
 ```bash
-$ helm install spire-demo spire-flex-0.1.0.tgz --set trustDoman=demo.company.com
+$ helm install spire-demo spire-flex-0.1.0.tgz --set trustdomain=demo.company.com
 ``` 
 
 or the preferred approach of putting the values in a values.yaml file
@@ -61,9 +61,9 @@ To install a tiered cluster setup, one must install one coordnating "root" clust
 and one or more "nested" clusters.
 
 ```bash
-$ helm install spire-demo-root spire-flex-0.1.0.tgz --set trustDoman=demo.company.com --set type=root
-$ helm install spire-demo-nested1 spire-flex-0.1.0.tgz --set trustDoman=demo.company.com --set type=nested
-$ helm install spire-demo-nested2 spire-flex-0.1.0.tgz --set trustDoman=demo.company.com --set type=nested
+$ helm install spire-demo-root spire-flex-0.1.0.tgz --set trustdomain=demo.company.com --set type=root
+$ helm install spire-demo-nested1 spire-flex-0.1.0.tgz --set trustdomain=demo.company.com --set type=nested
+$ helm install spire-demo-nested2 spire-flex-0.1.0.tgz --set trustdomain=demo.company.com --set type=nested
 ``` 
 
 or the preferred approach of putting the values in a values.yaml file
@@ -93,7 +93,7 @@ To change values in an already deployed cluster, one uses the helm upgrade
 command with the new values.
 
 ```bash
-$ helm upgrade spire-demo spire-flex-0.1.0.tgz --set trustDomain=dev.company.com
+$ helm upgrade spire-demo spire-flex-0.1.0.tgz --set trustdomain=dev.company.com
 ```
 
 or the preferred approach of putting the values in a values.yaml file

--- a/spire-flex/templates/agent-configmap.yaml
+++ b/spire-flex/templates/agent-configmap.yaml
@@ -12,6 +12,7 @@ data:
     agent {
       server_address = {{ default (printf "%s-server" .Release.Name) (.Values.server).serviceName | quote }}
       server_port = {{ default 8081 (.Values.server).servicePort }}
+      trust_domain = {{ required "The trustdomain must be set" .Values.trustdomain | quote }}
     }
     
     plugins {

--- a/spire-flex/tests/agentConfigFilePath.yaml
+++ b/spire-flex/tests/agentConfigFilePath.yaml
@@ -7,6 +7,7 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.configFile: "/etc/spire/agent_goofy"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -34,6 +35,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.configFile: "/etc/spire/agent_goofy"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"

--- a/spire-flex/tests/agentHealthCheckBindPort.yaml
+++ b/spire-flex/tests/agentHealthCheckBindPort.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindPort: 9091
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.bindPort: 9091
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 9091
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 9091
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckDefault.yaml
+++ b/spire-flex/tests/agentHealthCheckDefault.yaml
@@ -8,6 +8,8 @@ templates:
 tests:
   - it: "Should render the correct agent_config file"
     template: agent-configmap.yaml
+    set:
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -20,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -40,65 +43,35 @@ tests:
 
   - it: "Expressed settings should correspond to agent daemonset probes"
     template: agent-daemonset.yaml
+    set:
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckDisabled.yaml
+++ b/spire-flex/tests/agentHealthCheckDisabled.yaml
@@ -7,6 +7,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.enable: false
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,6 +20,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -33,6 +35,7 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.enable: false
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -40,13 +43,7 @@ tests:
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
       - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")]
       - isNull:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
       - isNull:

--- a/spire-flex/tests/agentHealthCheckEnabled.yaml
+++ b/spire-flex/tests/agentHealthCheckEnabled.yaml
@@ -7,6 +7,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.enable: true
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,6 +20,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -41,65 +43,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.enable: true
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "127.0.0.1"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.bindAddress: "127.0.0.1"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "127.0.0.1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "127.0.0.1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "127.0.0.1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddressAny.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "0.0.0.0"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.bindAddress: "0.0.0.0"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "0.0.0.0"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "0.0.0.0"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "0.0.0.0"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckIPv4BindAddress_failOnBadValue.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv4BindAddress_failOnBadValue.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "192.168.0.23"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - failedTemplate:
           errorMessage: | 

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "::1"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.bindAddress: "::1"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "::1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "::1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "::1"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddressAny.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "::"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.bindAddress: "::"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "::"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "::"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "::"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckIPv6BindAddress_failOnBadValue.yaml
+++ b/spire-flex/tests/agentHealthCheckIPv6BindAddress_failOnBadValue.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.bindAddress: "2324:2930::2349:9702"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - failedTemplate:
           errorMessage: | 

--- a/spire-flex/tests/agentHealthCheckLivePath.yaml
+++ b/spire-flex/tests/agentHealthCheckLivePath.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.livePath: "/i_am_alive"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,65 +45,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.livePath: "/i_am_alive"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/i_am_alive"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/ready"

--- a/spire-flex/tests/agentHealthCheckReadyPath.yaml
+++ b/spire-flex/tests/agentHealthCheckReadyPath.yaml
@@ -7,6 +7,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.healthCheck.readyPath: "/i_am_ready"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,6 +20,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -41,65 +43,34 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.healthCheck.readyPath: "/i_am_ready"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.path
           value: "/i_am_ready"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].readinessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.path
           value: "/live"
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].livenessProbe.httpGet.port
           value: 80
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.host
           value: "localhost"
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].startupProbe.httpGet.path
           value: "/i_am_ready"

--- a/spire-flex/tests/agentImageAgentImageName.yaml
+++ b/spire-flex/tests/agentImageAgentImageName.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.image.name: "mycorp/agent"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io/mycorp/agent:1.8.0"

--- a/spire-flex/tests/agentImageAgentImageRegistry.yaml
+++ b/spire-flex/tests/agentImageAgentImageRegistry.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.image.registry: "docker"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "docker/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageAgentImageRegistryPort.yaml
+++ b/spire-flex/tests/agentImageAgentImageRegistryPort.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.image.registryPort: 3032
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io:3032/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageAgentImageTag.yaml
+++ b/spire-flex/tests/agentImageAgentImageTag.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.image.tag: "latest"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io/spiffe/spire-agent:latest"

--- a/spire-flex/tests/agentImageDefault.yaml
+++ b/spire-flex/tests/agentImageDefault.yaml
@@ -5,22 +5,13 @@ tests:
   - it: "Should use the default gcp 1.8.0 image"
     template: agent-daemonset.yaml
     set:
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageRegistry.yaml
+++ b/spire-flex/tests/agentImageImageRegistry.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       image.registry: "docker"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "docker/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageRegistryPort.yaml
+++ b/spire-flex/tests/agentImageImageRegistryPort.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       image.registryPort: 3032
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io:3032/spiffe/spire-agent:1.8.0"

--- a/spire-flex/tests/agentImageImageTag.yaml
+++ b/spire-flex/tests/agentImageImageTag.yaml
@@ -6,22 +6,13 @@ tests:
     template: agent-daemonset.yaml
     set:
       image.tag: "latest"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
           kind: "DaemonSet"
           name: "RELEASE-NAME-agent-daemonset"
           namespace: "NAMESPACE"
-      - isNotNull:
-          path: spec
-      - isNotNull:
-          path: spec.template
-      - isNotNull:
-          path: spec.template.spec
-      - isNotNull:
-          path: spec.template.spec.containers
-      - isNotNull:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
       - equal:
           path: spec.template.spec.containers[?(@.name == "RELEASE-NAME-agent")].image
           value: "ghcr.io/spiffe/spire-agent:latest"

--- a/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_allFields.yaml
@@ -15,6 +15,7 @@ tests:
         "encryption = true",
         "rotationMin = 35",
       ]
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -27,6 +28,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_enabledOff.yaml
@@ -9,6 +9,7 @@ tests:
       agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
       agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
       agent.keyManager.custom.enabled: false
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_missingChecksum.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_missingChecksum.yaml
@@ -7,6 +7,7 @@ tests:
     set:
       agent.keyManager.type: custom
       agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - failedTemplate:
           errorMessage: "agent.keyManager.custom.checksum must be set"

--- a/spire-flex/tests/agentKeyManager_typeCustom_missingCmd.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_missingCmd.yaml
@@ -7,6 +7,7 @@ tests:
     set:
       agent.keyManager.type: custom
       agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - failedTemplate:
           errorMessage: "agent.keyManager.custom.cmd must be set"

--- a/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withData.yaml
@@ -13,6 +13,7 @@ tests:
         "encryption = true",
         "rotationMin = 35",
       ]
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -25,6 +26,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
+++ b/spire-flex/tests/agentKeyManager_typeCustom_withName.yaml
@@ -9,6 +9,7 @@ tests:
       agent.keyManager.custom.name: "bonzaiKeyManager"
       agent.keyManager.custom.cmd: "/usr/bin/customKeyManager"
       agent.keyManager.custom.checksum: "3f363c538588bbbbbcbe5374274c2c01f0d1387e012b68a22178e3dd790dc26c"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {

--- a/spire-flex/tests/agentKeyManager_typeDisk.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk.yaml
@@ -7,6 +7,7 @@ tests:
     template: agent-configmap.yaml
     set:
       agent.keyManager.type: disk
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,6 +20,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {
@@ -41,6 +43,7 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.keyManager.type: disk
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -58,6 +61,7 @@ tests:
     template: agent-daemonset.yaml
     set:
       agent.keyManager.type: disk
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory.yaml
@@ -8,6 +8,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -20,6 +21,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {
@@ -44,6 +46,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -62,6 +65,7 @@ tests:
     set:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"

--- a/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
+++ b/spire-flex/tests/agentKeyManager_typeDisk_directory_and_hostpath.yaml
@@ -9,6 +9,7 @@ tests:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
       agent.hostpath.keyManagerDir: "/opt/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
 
             plugins {
@@ -46,6 +48,7 @@ tests:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
       agent.hostPath.keyManagerDir: "/opt/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"
@@ -65,6 +68,7 @@ tests:
       agent.keyManager.type: disk
       agent.keyManager.disk.directory: "/var/lib/spire-agent/"
       agent.hostPath.keyManagerDir: "/opt/lib/spire-agent/"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "apps/v1"

--- a/spire-flex/tests/server_serviceName.yaml
+++ b/spire-flex/tests/server_serviceName.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       server.serviceName: "myserver"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "myserver"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,6 +45,7 @@ tests:
     template: server-service.yaml
     set:
       server.serviceName: "myserver"
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"

--- a/spire-flex/tests/server_serviceName_default.yaml
+++ b/spire-flex/tests/server_serviceName_default.yaml
@@ -7,6 +7,8 @@ templates:
 tests:
   - it: "Should render with server_address = \"RELEASE-NAME-server\""
     template: agent-configmap.yaml
+    set:
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,6 +21,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -39,6 +42,8 @@ tests:
 
   - it: "Should render with name = \"RELEASE-NAME-server\""
     template: server-service.yaml
+    set:
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"

--- a/spire-flex/tests/server_servicePort.yaml
+++ b/spire-flex/tests/server_servicePort.yaml
@@ -9,6 +9,7 @@ tests:
     template: agent-configmap.yaml
     set:
       server.servicePort: 5000
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -21,6 +22,7 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 5000
+              trust_domain = "dev.mycorp.com"
             }
             
             plugins {
@@ -43,6 +45,7 @@ tests:
     template: server-service.yaml
     set:
       server.servicePort: 5000
+      trustdomain: "dev.mycorp.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"

--- a/spire-flex/tests/server_trustdomain.yaml
+++ b/spire-flex/tests/server_trustdomain.yaml
@@ -1,12 +1,11 @@
-suite: test .agent.keyManager.type memory
+suite: test .trustdomain prod.yoyodyne.com
 templates:
   - agent-configmap.yaml
 tests:
-  - it: "Should render the correct agent_config file"
+  - it: ".trustdomain set to prod.yoyodyne.com sets trust_domain = \"prod.yoyodyne.com\""
     template: agent-configmap.yaml
     set:
-      agent.keyManager.type: "memory"
-      trustdomain: "dev.mycorp.com"
+      trustdomain: "prod.yoyodyne.com"
     asserts:
       - containsDocument:
           apiVersion: "v1"
@@ -19,11 +18,14 @@ tests:
             agent {
               server_address = "RELEASE-NAME-server"
               server_port = 8081
-              trust_domain = "dev.mycorp.com"
+              trust_domain = "prod.yoyodyne.com"
             }
-
+            
             plugins {
-              KeyManager "memory" {
+              KeyManager "disk" {
+                plugin_data {
+                  directory = "/opt/spire/data/agent/"
+                }
               }
             }
             

--- a/spire-flex/tests/server_trustdomain_unset.yaml
+++ b/spire-flex/tests/server_trustdomain_unset.yaml
@@ -1,0 +1,12 @@
+suite: test .trustdomain (unset)
+set:
+  Release.Name: devcluster
+templates:
+  - agent-configmap.yaml
+tests:
+  - it: "Should fail to render as the trustdomain is not set"
+    template: agent-configmap.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The trustdomain must be set

--- a/spire-flex/values.schema.json
+++ b/spire-flex/values.schema.json
@@ -38,6 +38,14 @@
                 }
             }
         },
+        "trustdomain": {
+            "type": "string",
+            "title": "The .trustdomain Schema",
+            "examples": [
+                "yoyodyne.com",
+                "dev.tyrellcorp.com"
+            ]
+        },
         "agent": {
             "type": "object",
             "default": {},


### PR DESCRIPTION
Add .trustdomain to the configuration settings.
Add .trustdomain to the configuration documentation. Add .trustdomain unit testing.
Add .trustdomain to the values.schema.yaml.
Update the README to use the correct trustdomain settings.